### PR TITLE
Fix type of Account::interest

### DIFF
--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -1,7 +1,7 @@
 /*
  * Firefly III API
  *
- * This is the official documentation of the Firefly III API. You can find accompanying documentation on the website of Firefly III itself (see below). Please report any bugs or issues. This version of the API is live from version v4.7.9 and onwards. You may use the \"Authorize\" button to try the API below. 
+ * This is the official documentation of the Firefly III API. You can find accompanying documentation on the website of Firefly III itself (see below). Please report any bugs or issues. This version of the API is live from version v4.7.9 and onwards. You may use the \"Authorize\" button to try the API below.
  *
  * The version of the OpenAPI document: 0.10.4
  * Contact: thegrumpydictator@gmail.com
@@ -76,7 +76,7 @@ pub struct Account {
     pub liability_start_date: Option<String>,
     /// Mandatory when type is liability. Interest percentage.
     #[serde(rename = "interest", skip_serializing_if = "Option::is_none")]
-    pub interest: Option<f32>,
+    pub interest: Option<String>,
     /// Mandatory when type is liability. Period over which the interest is calculated.
     #[serde(rename = "interest_period", skip_serializing_if = "Option::is_none")]
     pub interest_period: Option<InterestPeriod>,


### PR DESCRIPTION
Using https://docs.rs/firefly-iii/0.1.0-alpha.6/firefly_iii/apis/trait.AccountsApi.html#tymethod.list_account with the demo data from https://demo.firefly-iii.org/login, an error is raised because the type of the value returned for Interest is a String, not f32 ("5.3").