### PR TITLE
Show more information for errors

### DIFF
--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -11,9 +11,9 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Reqwest(_) => write!(f, "reqwest error"),
-            Self::Serde(_) => write!(f, "serde error"),
-            Self::Io(_) => write!(f, "i/o error"),
+            Self::Reqwest(e) => write!(f, "reqwest error - {}", e.to_string()),
+            Self::Serde(e) => write!(f, "serde error - {}", e.to_string()),
+            Self::Io(e) => write!(f, "i/o error - {}", e.to_string()),
         }
     }
 }


### PR DESCRIPTION
Feel free to close this if it is not something you like, but I found it helpful. When, for example, the Firefly API change, at least you get a message that can point towards where the error is happening. For example:

`reqwest error - error decoding response body: invalid type: string "344.51", expected f64 at line 1 column 328`